### PR TITLE
Change: Use bitmasking for classic controller

### DIFF
--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerClassic.cs
@@ -64,35 +64,9 @@ namespace DenshaDeGoInput
 		}
 
 		/// <summary>
-		/// Class for the pressed state of the buttons used by the controller.
-		/// </summary>
-		internal class PressedButtons
-		{
-			internal bool Select;
-			internal bool Start;
-			internal bool A;
-			internal bool B;
-			internal bool C;
-			internal bool Power1;
-			internal bool Power2;
-			internal bool Power3;
-			internal bool Brake1;
-			internal bool Brake3;
-			internal bool Brake2;
-			internal bool Brake4;
-
-
-		}
-
-		/// <summary>
 		/// The button indices of the buttons used by the controller.
 		/// </summary>
 		internal static ButtonIndices ButtonIndex = new ButtonIndices();
-
-		/// <summary>
-		/// The pressed state of the buttons used by the controller.
-		/// </summary>
-		internal static PressedButtons ButtonPressed = new PressedButtons();
 
 		/// <summary>
 		/// Checks whether a joystick is a classic console controller.
@@ -113,93 +87,35 @@ namespace DenshaDeGoInput
 		/// Reads the input from the controller.
 		/// </summary>
 		/// <param name="joystick">The state of the joystick to read input from.</param>
-		internal static void ReadInput(JoystickState joystick)
+		/// <param name="powerNotch">The returned power notch</param>
+		/// <param name="brakeNotch">The returned brake notch</param>
+		internal static void ReadInput(JoystickState joystick, out InputTranslator.PowerNotches powerNotch, out InputTranslator.BrakeNotches brakeNotch)
 		{
-			ButtonPressed.Select = joystick.IsButtonDown(ButtonIndex.Select);
-			ButtonPressed.Start = joystick.IsButtonDown(ButtonIndex.Start);
-			ButtonPressed.A = joystick.IsButtonDown(ButtonIndex.A);
-			ButtonPressed.B = joystick.IsButtonDown(ButtonIndex.B);
-			ButtonPressed.C = joystick.IsButtonDown(ButtonIndex.C);
-			ButtonPressed.Power1 = joystick.IsButtonDown(ButtonIndex.Power1);
-			ButtonPressed.Brake1 = joystick.IsButtonDown(ButtonIndex.Brake1);
-			ButtonPressed.Brake2 = joystick.IsButtonDown(ButtonIndex.Brake2);
-			ButtonPressed.Brake3 = joystick.IsButtonDown(ButtonIndex.Brake3);
-			ButtonPressed.Brake4 = joystick.IsButtonDown(ButtonIndex.Brake4);
-
+			powerNotch = InputTranslator.PowerNotches.None;
+			brakeNotch = InputTranslator.BrakeNotches.None;
+			powerNotch = joystick.IsButtonDown(ButtonIndex.Power1) ? powerNotch | InputTranslator.PowerNotches.Power1 : powerNotch & ~InputTranslator.PowerNotches.Power1;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake1) ? brakeNotch | InputTranslator.BrakeNotches.Brake1 : brakeNotch & ~InputTranslator.BrakeNotches.Brake1;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake2) ? brakeNotch | InputTranslator.BrakeNotches.Brake2 : brakeNotch & ~InputTranslator.BrakeNotches.Brake2;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake3) ? brakeNotch | InputTranslator.BrakeNotches.Brake3 : brakeNotch & ~InputTranslator.BrakeNotches.Brake3;
+			brakeNotch = joystick.IsButtonDown(ButtonIndex.Brake4) ? brakeNotch | InputTranslator.BrakeNotches.Brake4 : brakeNotch & ~InputTranslator.BrakeNotches.Brake4;
+			
 			if (usesHat)
 			{
 				// The adapter uses the hat to map the direction buttons.
 				// This is the case of some PlayStation adapters.
-				ButtonPressed.Power2 = joystick.GetHat((JoystickHat)hatIndex).IsLeft;
-				ButtonPressed.Power3 = joystick.GetHat((JoystickHat)hatIndex).IsRight;
+				powerNotch = joystick.GetHat((JoystickHat)hatIndex).IsLeft ? powerNotch | InputTranslator.PowerNotches.Power2 : powerNotch & ~InputTranslator.PowerNotches.Power2;
+				powerNotch = joystick.GetHat((JoystickHat)hatIndex).IsRight ? powerNotch | InputTranslator.PowerNotches.Power3 : powerNotch & ~InputTranslator.PowerNotches.Power3;
 			}
 			else
 			{
 				// The adapter maps the direction buttons to independent buttons.
-				ButtonPressed.Power2 = joystick.IsButtonDown(ButtonIndex.Power2);
-				ButtonPressed.Power3 = joystick.IsButtonDown(ButtonIndex.Power3);
+				powerNotch = joystick.IsButtonDown(ButtonIndex.Power2) ? powerNotch | InputTranslator.PowerNotches.Power2 : powerNotch & ~InputTranslator.PowerNotches.Power2;
+				powerNotch = joystick.IsButtonDown(ButtonIndex.Power3) ? powerNotch | InputTranslator.PowerNotches.Power3 : powerNotch & ~InputTranslator.PowerNotches.Power3;
 			}
 
-			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && !ButtonPressed.Brake4)
+			if (usesHat && powerNotch == InputTranslator.PowerNotches.P4)
 			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Emergency;
-			}
-			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && !ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B8;
-			}
-			if (ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && !ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B7;
-			}
-			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B6;
-			}
-			if (ButtonPressed.Brake1 && !ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B5;
-			}
-			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B4;
-			}
-			if (ButtonPressed.Brake1 && ButtonPressed.Brake2 && !ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B3;
-			}
-			if (!ButtonPressed.Brake1 && !ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B2;
-			}
-			if (ButtonPressed.Brake1 && !ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.B1;
-			}
-			if (!ButtonPressed.Brake1 && ButtonPressed.Brake2 && ButtonPressed.Brake3 && ButtonPressed.Brake4)
-			{
-				InputTranslator.BrakeNotch = InputTranslator.BrakeNotches.Released;
-			}
-
-			if (!ButtonPressed.Power1 && ButtonPressed.Power2 && ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
-			}
-			if (ButtonPressed.Power1 && !ButtonPressed.Power2 && ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P1;
-			}
-			if (!ButtonPressed.Power1 && !ButtonPressed.Power2 && ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P2;
-			}
-			if (ButtonPressed.Power1 && ButtonPressed.Power2 && !ButtonPressed.Power3)
-			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P3;
-			}
-			if (!ButtonPressed.Power1 && ButtonPressed.Power2 && !ButtonPressed.Power3)
-			{
-				if (usesHat && InputTranslator.PreviousPowerNotch < InputTranslator.PowerNotches.P3)
+				if (InputTranslator.PreviousPowerNotch < InputTranslator.PowerNotches.P3)
 				{
 					// Hack for adapters which map the direction buttons to a hat and confuse N with P4
 					InputTranslator.PowerNotch = InputTranslator.PowerNotches.N;
@@ -209,17 +125,17 @@ namespace DenshaDeGoInput
 					InputTranslator.PowerNotch = InputTranslator.PowerNotches.P4;
 				}
 			}
-			if (ButtonPressed.Power1 && !ButtonPressed.Power2 && !ButtonPressed.Power3)
+			else
 			{
-				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
+				InputTranslator.PowerNotch = powerNotch;
 			}
-
-			InputTranslator.ControllerButtons.Select = (OpenTK.Input.ButtonState)(ButtonPressed.Select ? 1 : 0);
-			InputTranslator.ControllerButtons.Start = (OpenTK.Input.ButtonState)(ButtonPressed.Start ? 1 : 0);
-			InputTranslator.ControllerButtons.A = (OpenTK.Input.ButtonState)(ButtonPressed.A ? 1 : 0);
-			InputTranslator.ControllerButtons.B = (OpenTK.Input.ButtonState)(ButtonPressed.B ? 1 : 0);
-			InputTranslator.ControllerButtons.C = (OpenTK.Input.ButtonState)(ButtonPressed.C ? 1 : 0);
+			InputTranslator.ControllerButtons.Select = joystick.GetButton(ButtonIndex.Select);
+			InputTranslator.ControllerButtons.Start = joystick.GetButton(ButtonIndex.Start);
+			InputTranslator.ControllerButtons.A = joystick.GetButton(ButtonIndex.A);
+			InputTranslator.ControllerButtons.B = joystick.GetButton(ButtonIndex.B);
+			InputTranslator.ControllerButtons.C = joystick.GetButton(ButtonIndex.C);
 		}
+
 
 		/// <summary>
 		/// Launches the calibration wizard to guess the button indices used by the adapter.

--- a/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/ControllerUnbalance.cs
@@ -97,9 +97,9 @@ namespace DenshaDeGoInput
 		{
 			// DGC-255/DGOC-44U
 			if (id == "0ae4:0003")
-				{
-					// DGC-255 has direction buttons
-					hasDirectionButtons = capabilities.HatCount > 0;
+			{
+				// DGC-255 has direction buttons
+				hasDirectionButtons = capabilities.HatCount > 0;
 				return true;
 			}
 			return false;
@@ -179,12 +179,12 @@ namespace DenshaDeGoInput
 				InputTranslator.PowerNotch = InputTranslator.PowerNotches.P5;
 			}
 
-			InputTranslator.ControllerButtons.Select = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Select) ? 1 : 0);
-			InputTranslator.ControllerButtons.Start = (ButtonState)(joystick.IsButtonDown(ButtonIndex.Start) ? 1 : 0);
-			InputTranslator.ControllerButtons.A = (ButtonState)(joystick.IsButtonDown(ButtonIndex.A) ? 1 : 0);
-			InputTranslator.ControllerButtons.B = (ButtonState)(joystick.IsButtonDown(ButtonIndex.B) ? 1 : 0);
-			InputTranslator.ControllerButtons.C = (ButtonState)(joystick.IsButtonDown(ButtonIndex.C) ? 1 : 0);
-			InputTranslator.ControllerButtons.D = (ButtonState)(joystick.IsButtonDown(ButtonIndex.D) ? 1 : 0);
+			InputTranslator.ControllerButtons.Select = joystick.GetButton(ButtonIndex.Select);
+			InputTranslator.ControllerButtons.Start = joystick.GetButton(ButtonIndex.Start);
+			InputTranslator.ControllerButtons.A = joystick.GetButton(ButtonIndex.A);
+			InputTranslator.ControllerButtons.B = joystick.GetButton(ButtonIndex.B);
+			InputTranslator.ControllerButtons.C = joystick.GetButton(ButtonIndex.C);
+			InputTranslator.ControllerButtons.D = joystick.GetButton(ButtonIndex.D);
 
 			if (hasDirectionButtons)
 			{

--- a/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
+++ b/source/InputDevicePlugins/DenshaDeGoInput/InputTranslator.cs
@@ -1,4 +1,4 @@
-﻿//Simplified BSD License (BSD-2-Clause)
+//Simplified BSD License (BSD-2-Clause)
 //
 //Copyright (c) 2020, Marc Riera, The OpenBVE Project
 //
@@ -46,36 +46,92 @@ namespace DenshaDeGoInput
 		/// <summary>
 		/// Enumeration representing brake notches.
 		/// </summary>
+		[Flags]
 		internal enum BrakeNotches
 		{
-			Released = 0,
-			B1 = 1,
-			B2 = 2,
-			B3 = 3,
-			B4 = 4,
-			B5 = 5,
-			B6 = 6,
-			B7 = 7,
-			B8 = 8,
-			Emergency = 9,
+			// The controller has 4 physical buttons.
+			// These do *not* map directly to the simulation
+
+			/// <summary>No buttons are pressed on the controller</summary>
+			None = 0,
+			/// <summary>The Brake1 button is pressed</summary>
+			Brake1 = 1,
+			/// <summary>The Brake2 button is pressed</summary>
+			Brake2 = 2,
+			/// <summary>The Brake3 button is pressed</summary>
+			Brake3 = 4,
+			/// <summary>The Brake4 button is pressed</summary>
+			Brake4 = 8,
+
+			// Our returned notches to the simulation are a bitflag button combination
+
+			/// <summary>Brakes are released</summary>
+			Released = Brake2 | Brake3 | Brake4,
+			/// <summary>Brake Notch B1</summary>
+			B1 = Brake1 | Brake3 | Brake4,
+			/// <summary>Brake Notch B2</summary>
+			B2 = Brake3 | Brake4,
+			/// <summary>Brake Notch B3</summary>
+			B3 = Brake1 | Brake2 | Brake4,
+			/// <summary>Brake Notch B4</summary>
+			B4 = Brake2 | Brake4,
+			/// <summary>Brake Notch B5</summary>
+			B5 = Brake1 | Brake4,
+			/// <summary>Brake Notch B6</summary>
+			B6 = Brake4,
+			/// <summary>Brake Notch B7</summary>
+			B7 = Brake1 | Brake2 | Brake3,
+			/// <summary>Brake Notch B8</summary>
+			B8 = Brake2 | Brake3,
+			/// <summary>Emergency</summary>
+			Emergency = Brake1 | Brake2 | Brake3 | Brake4,
 		};
 
 		/// <summary>
 		/// Enumeration representing power notches.
 		/// </summary>
+		[Flags]
 		internal enum PowerNotches
 		{
-			N = 0,
-			P1 = 1,
-			P2 = 2,
-			P3 = 3,
-			P4 = 4,
-			P5 = 5,
+			// The controller has 3 physical buttons.
+			// These do *not* map directly to the simulation
+
+			/// <summary>No buttons are pressed on the controller</summary>
+			None = 0,
+			/// <summary>The Power1 button is pressed</summary>
+			Power1 = 1,
+			/// <summary>The Power2 button is pressed</summary>
+			Power2 = 2,
+			/// <summary>The Power3 button is pressed</summary>
+			Power3 = 4,
+			
+			// Our returned notches to the simulation are a bitflag button combination
+
+			/// <summary>Power is in N</summary>
+			N = Power2 | Power3,
+			/// <summary>Power notch P1</summary>
+			P1 = Power1 | Power3,
+			/// <summary>Power notch P2</summary>
+			P2 = Power3,
+			/// <summary>Power notch P3</summary>
+			P3 = Power1 | Power2,
+			/// <summary>Power notch P4</summary>
+			P4 = Power2,
+			/// <summary>Power notch P5</summary>
+			P5 = Power1,
 		};
 
-		/// <summary>
-		/// Class with the state of the buttons.
-		/// </summary>
+		[Flags]
+		internal enum ControllerFunctionButtons
+		{
+			None = 0,
+			Start = 1,
+			Select = 2,
+			A = 4,
+			B = 8,
+			C = 16
+		}
+
 		internal class ButtonState
 		{
 			internal OpenTK.Input.ButtonState Select;
@@ -213,7 +269,7 @@ namespace DenshaDeGoInput
 			switch (ControllerModel)
 			{
 				case ControllerModels.Classic:
-					ControllerClassic.ReadInput(Joystick.GetState(activeControllerIndex));
+					ControllerClassic.ReadInput(Joystick.GetState(activeControllerIndex), out PowerNotch, out BrakeNotch);
 					return;
 				case ControllerModels.Unbalance:
 					ControllerUnbalance.ReadInput(Joystick.GetState(activeControllerIndex));


### PR DESCRIPTION
This does some minor bitmask gymnastics to get rid of all your bools & the associated horrid if statements.
Will be very marginally faster, although in practice this isn't going to matter a jot as the code is too trivial to matter.

I *think* this should work, but it's slightly hard to test without the thing in front of me.
Only thing I don't like so much is adding the physical buttons into the notches enums, but otherwise it looks ridiculous when bitshifting around & is somewhat less readable.

(n.b. You could equally use the raw values in the bitshifts within the enums, but that's less readable somewhere else)

It also fixes the duplicated P1 / P2 review comment (assuming the gist documentation is accurate); I presume this was a typo.